### PR TITLE
setup.py: exclude tests from built package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setuptools.setup(
     author="Alexander Overvoorde",
     author_email="overv161@gmail.com",
     license="Apache",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["outrun.tests*"]),
     entry_points={"console_scripts": ["outrun = outrun.__main__:main"]},
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
It might be a matter of opinion, but built packages don't usually contain the unit and integration tests. Since this package at least puts them under the `outrun.` prefix and thus can't collide with other packages, it's mostly a matter of space savings.